### PR TITLE
Switch map to light tile layer

### DIFF
--- a/script.js
+++ b/script.js
@@ -25,7 +25,7 @@ const routePointIcon = L.divIcon({
 
 // Térkép inicializálása
 map = L.map('map').setView([47.4979, 19.0402], 13);
-L.tileLayer('https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png', {
+L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png', {
     attribution: '© OpenStreetMap © CARTO',
 }).addTo(map);
 


### PR DESCRIPTION
## Summary
- change Leaflet map tiles from dark theme to light/grey style

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686981bcd9448327a66603d59975c1ab